### PR TITLE
Broaden $function to accept any callable, not just closures.

### DIFF
--- a/Cache.php
+++ b/Cache.php
@@ -259,7 +259,7 @@ class Cache
      * @param $file returns the cache file or the file contents
      * @param $actual returns the actual cache file
      */
-    public function getOrCreate($filename, array $conditions = array(), \Closure $function, $file = false, $actual = false)
+    public function getOrCreate($filename, array $conditions = array(), callable $function, $file = false, $actual = false)
     {
         $cacheFile = $this->getCacheFile($filename, true, true);
         $data = null;
@@ -268,7 +268,7 @@ class Cache
             $data = file_get_contents($cacheFile);
         } else {
             @unlink($cacheFile);
-            $data = $function($cacheFile);
+            $data = call_user_func($function, $cacheFile);
 
             // Test if the closure wrote the file or if it returned the data
             if (!file_exists($cacheFile)) {
@@ -284,7 +284,7 @@ class Cache
     /**
      * Alias to getOrCreate with $file = true
      */
-    public function getOrCreateFile($filename, array $conditions = array(), \Closure $function, $actual = false)
+    public function getOrCreateFile($filename, array $conditions = array(), callable $function, $actual = false)
     {
         return $this->getOrCreate($filename, $conditions, $function, true, $actual);
     }

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
         }
     ],
     "target-dir": "Gregwar/Cache",
+    "require": {
+        "php": ">=5.4"
+    },
     "autoload": {
         "psr-0": {
             "Gregwar\\Cache": ""

--- a/tests/CacheTests.php
+++ b/tests/CacheTests.php
@@ -77,6 +77,21 @@ class CacheTests extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Testing the getOrCreate function with a callable
+     */
+    public function testGetOrCreateWithCallable()
+    {
+        $cache = $this->getCache();
+
+        $this->assertFalse($cache->exists('testing.txt'));
+
+        $data = $cache->getOrCreate('testing.txt', array(), array($this, 'getAnimal'));
+
+        $this->assertTrue($cache->exists('testing.txt'));
+        $this->assertEquals('orangutan', $data);
+    }
+
+    /**
      * Testing the getOrCreate function with $file=true
      */
     public function testGetOrCreateFile()
@@ -106,6 +121,11 @@ class CacheTests extends \PHPUnit_Framework_TestCase
         });
 
         $this->assertEquals('some-data', $data);
+    }
+
+    public function getAnimal()
+    {
+        return 'orangutan';
     }
 
     protected function getCache()


### PR DESCRIPTION
Only accepting closures is annoying when you have a function that
already exists.

For example,

``` php
function getData()
{
    // ...
    return $results;
}
```

This can now be cached by passing the string 'getData' as the function
rather than having to wrap the function in a closure.  Similarly, if
that function was defined on an object you could now pass array($object,
'getData').

The type hint is PHP 5.4 or newer, hence the composer.json change.
