### PR TITLE
Fixing spurious unlink warning

### DIFF
--- a/Cache.php
+++ b/Cache.php
@@ -293,8 +293,7 @@ class Cache
         if ($this->check($filename, $conditions)) {
             $data = file_get_contents($cacheFile);
         } else {
-            if(file_exists($cacheFile))
-            {
+            if(file_exists($cacheFile)) {
                 unlink($cacheFile);
             }
 


### PR DESCRIPTION
I'm getting spurious warnings from my Symfony project using GregwarImageBundle. These are being picked up by Elao ErrorNotifier Bundle and emailed to me which is getting annoying! This pull request seems to fix it.

The errors look like this:

```
Warning: unlink(/blah/app/../web/resized-images/a/3/c/1/0/a3c10998e21ac39b4240160367cbf20e2c10927f.jpg): No such file or directory in /blah/vendor/gregwar/cache/Gregwar/Cache/Cache.php line 262
```
