### PR TITLE
Fixed PHP8 issues

### DIFF
--- a/Cache.php
+++ b/Cache.php
@@ -11,14 +11,15 @@ class Cache implements CacheInterface
 {
     /**
      * Cache directory
+     * @var string
      */
     protected $cacheDirectory;
 
     /**
      * Use a different directory as actual cache
-     * @var string
+     * @var string|null
      */
-    protected $actualCacheDirectory = null;
+    protected $actualCacheDirectory;
 
     /**
      * Prefix directories size
@@ -76,7 +77,7 @@ class Cache implements CacheInterface
     /**
      * Sets the actual cache directory
      *
-     * @param string $actualCacheDirectory the actual cache directory
+     * @param string|null $actualCacheDirectory the actual cache directory
      * @return self
      */
     public function setActualCacheDirectory($actualCacheDirectory = null)
@@ -321,7 +322,7 @@ class Cache implements CacheInterface
      * @return string
      * @throws \InvalidArgumentException
      */
-    public function getOrCreate($filename, array $conditions = array(), $function, $file = false, $actual = false)
+    public function getOrCreate($filename, array $conditions, $function, $file = false, $actual = false)
     {
         if (!is_callable($function)) {
             throw new \InvalidArgumentException('The argument $function should be callable');
@@ -358,7 +359,7 @@ class Cache implements CacheInterface
      * @return string
      * @throws \InvalidArgumentException
      */
-    public function getOrCreateFile($filename, array $conditions = array(), $function, $actual = false)
+    public function getOrCreateFile($filename, array $conditions, $function, $actual = false)
     {
         return $this->getOrCreate($filename, $conditions, $function, true, $actual);
     }

--- a/CacheInterface.php
+++ b/CacheInterface.php
@@ -20,7 +20,7 @@ interface CacheInterface {
     /**
      * Sets the actual cache directory
      *
-     * @param string $actualCacheDirectory the actual cache directory
+     * @param string|null $actualCacheDirectory the actual cache directory
      * @return self
      */
     public function setActualCacheDirectory($actualCacheDirectory = null);
@@ -114,7 +114,7 @@ interface CacheInterface {
      * @return string
      * @throws \InvalidArgumentException
      */
-    public function getOrCreate($filename, array $conditions = array(), $function, $file = false, $actual = false);
+    public function getOrCreate($filename, array $conditions, $function, $file = false, $actual = false);
 
     /**
      * Alias to getOrCreate with $file = true
@@ -126,6 +126,6 @@ interface CacheInterface {
      * @return string
      * @throws \InvalidArgumentException
      */
-    public function getOrCreateFile($filename, array $conditions = array(), $function, $actual = false);
+    public function getOrCreateFile($filename, array $conditions, $function, $actual = false);
 
 }


### PR DESCRIPTION
This pull request fixes #33.

My take on this is that having default value before required parameter has no effect and the default value gets ignored. Interface break can be handled by inceasing version number of the library.